### PR TITLE
Chapter 13: RHI vs BUS - Heat Pump Subsidy Policy Analysis

### DIFF
--- a/chapters/13-rhi-vs-bus.md
+++ b/chapters/13-rhi-vs-bus.md
@@ -1,6 +1,6 @@
 # Chapter 13: RHI vs BUS - Heating Policy Confusion
 
-NOTE: What do RHI and BUS stand for?
+The **Renewable Heat Incentive (RHI)** was a government scheme running from 2014 to 2022 that paid homeowners quarterly tariffs over seven years based on the renewable heat their systems produced. It was replaced by the **Boiler Upgrade Scheme (BUS)**, which from April 2022 instead offers a one-off upfront grant of £7,500 towards heat pump installation costs. This shift from ongoing payments to upfront capital fundamentally changed which households benefit most from heat pump subsidies.
 
 ## The last 50 years - the rise and rise of the gas combi-boiler
 
@@ -38,3 +38,192 @@ Had we invested more in domestic energy sources like nuclear, wind and shale gas
 
 *For a detailed analysis of the UK's missed opportunity with shale gas development, including the economic benefits, environmental considerations, and political factors that led to its rejection, see [Chapter 21: Shale Gas - A Missed Opportunity](21-shale-gas.md).*
 
+## The RHI: paying for heat produced
+
+The Renewable Heat Incentive was launched for domestic properties in April 2014, offering quarterly payments over seven years based on the estimated heat demand of the property. By its final year, the tariff rates had reached 10.85 pence per kWh for air source heat pumps (ASHPs) and a much more generous 21.16 pence per kWh for ground source heat pumps (GSHPs).
+
+However, these payments were subject to heat demand limits, introduced in 2017 to cap the total subsidy available. For ASHPs, payments were capped at 20,000 kWh of annual heat demand, meaning the maximum payout was around £9,400 over seven years (roughly £1,350 per year). For GSHPs, the limit was 30,000 kWh, but with the higher tariff rate, the maximum payout could reach an impressive £32,000 over seven years.
+
+These figures made the RHI extraordinarily attractive for certain types of property. A large detached home with high heat demand, particularly one off the gas grid and currently using expensive heating oil, could receive substantial ongoing income from the scheme. The combination of high heat demand and the ability to switch from oil (which was never cheap) to a heat pump created a compelling financial case, at least for those who could afford the upfront installation costs.
+
+## The March 2022 rush
+
+The RHI closed to new applicants at midnight on 31 March 2022. In the months leading up to this deadline, there was a predictable scramble to get installations completed. According to MCS (the Microgeneration Certification Scheme), 2022 saw 32,910 certified heat pump installations, with 29,490 of these being air source heat pumps. This was driven largely by a massive spike in March 2022 as households rushed to beat the deadline.
+
+This represented the largest monthly increase in heat pump installations in the scheme's history. Homeowners who had been deliberating for years suddenly found the urgency to commit, knowing that the generous seven-year payment stream was about to disappear forever.
+
+Those who made it in under the wire will continue receiving payments until March 2029. And crucially, their tariff rates are indexed to CPI inflation each April, meaning that the 10.85p rate secured in 2022 has already risen to approximately 12-13p per kWh by 2025, following the sharp inflation spike of 2022-23.
+
+## RHI and the spark gap: a solved problem
+
+It's worth pausing to consider what the RHI tariff actually meant for heat pump running costs, because it effectively eliminated the "spark gap" problem that continues to plague heat pump economics today.
+
+The spark gap refers to the roughly 4:1 ratio between electricity and gas prices. With electricity at around 24p per kWh and gas at around 6p, a gas boiler running at 90% efficiency produces heat at about 6.7p per kWh. A heat pump with a typical coefficient of performance (COP) of 3 produces heat at around 8p per kWh (24p divided by 3). Despite being three times more efficient, the heat pump is still marginally more expensive to run than the gas boiler.
+
+The RHI completely inverted this calculation. Crucially, the 10.85p tariff was paid per kWh of **heat produced**, not per kWh of electricity consumed. With a COP of 3, each kWh of electricity generates 3 kWh of heat, meaning the RHI payment was effectively 32.5p per kWh of electricity used (3 × 10.85p).
+
+Against an electricity cost of 24p per kWh, this meant RHI recipients were effectively being **paid** around 8-9p for every kWh of electricity they used for heating. Running the heat pump wasn't just cheaper than gas, it was a source of income. Factor in the inflation indexation pushing tariffs above 12p per kWh of heat by 2025, and those final RHI recipients are receiving close to 36-40p per kWh of electricity consumed, making heat pump operation extraordinarily profitable.
+
+This explains why the March 2022 rush was so intense, and why those who secured RHI accreditation just before the deadline made such a shrewd financial decision. For them, the spark gap doesn't just not exist; it runs dramatically in their favour until 2029.
+
+## The moral hazard problem
+
+Had the RHI continued beyond 2022 with its inflation-indexed tariffs, we might have faced a version of Northern Ireland's infamous "Cash for Ash" scandal. The Non-Domestic RHI scheme in Northern Ireland was so generous, and crucially had no cap on payments, that businesses were incentivised to burn wood pellets simply to collect the subsidy. People heated empty sheds and barns because the RHI payment exceeded the cost of the fuel. The resulting scandal cost taxpayers nearly £500 million and brought down the Northern Ireland Executive in 2017.
+
+The GB domestic scheme avoided the worst excesses through its heat demand limits, which capped payments based on the property's EPC-assessed heat requirement rather than actual consumption. You couldn't game the system by leaving windows open or heating unused rooms, because your payments were fixed regardless of how much heat you actually produced.
+
+However, the fundamental moral hazard remained. Consider a typical three-bedroom semi-detached house with an EPC-assessed heat demand of 10,000 kWh per year. Under the RHI at 2025 inflation-adjusted rates of around 13p per kWh of heat, this property would receive £1,300 annually. Running the heat pump with a COP of 3 requires about 3,333 kWh of electricity, costing around £800 at current prices. Net position: the household is **paid £500 per year** to heat their home.
+
+Compare this to their neighbour with a gas boiler, paying roughly £670 per year for the same heat output. The heat pump household is £1,170 per year better off.
+
+Now consider what happens if the heat pump household invests £5,000 in cavity wall and loft insulation, reducing their heat demand from 10,000 kWh to 7,000 kWh. Their RHI payment drops to £910 per year. Their electricity cost falls to £560. Net position: now only £350 profit per year, down from £500. The insulation investment has **reduced their annual income by £150**. At that rate, it would take over 30 years to recoup the insulation cost, even though the work is environmentally beneficial and would make the home more comfortable.
+
+This is the moral hazard in action. The scheme rewarded heat demand rather than heat pump efficiency, which ran counter to the broader goal of reducing energy consumption.
+
+To be fair to the scheme's designers, the seven-year payment guarantee was itself an important safeguard. Homeowners making significant capital investments needed certainty that the government wouldn't pull the rug out from under them. The "grandfathering" provisions meant that once accredited, your tariff rate could only ever increase (with inflation), never decrease. This gave investors confidence, but it also meant the Treasury had no mechanism to correct the increasingly generous economics as energy prices rose. Once someone was enrolled, their payments were locked in until 2029 regardless of how the market evolved.
+
+With electricity prices spiking in 2022-23 and CPI-indexed tariffs rising accordingly, the economics became increasingly perverse. A scheme designed when electricity cost 12-15p per kWh looked very different when prices hit 30p+. Had it continued accepting new applicants, the cost to the Treasury would have ballooned, and the incentives would have pushed in exactly the wrong direction: more consumption, less efficiency investment.
+
+## The fabric first question
+
+The RHI's perverse incentive against insulation highlights a broader policy failure: the lack of any joined-up approach between heat pump subsidies and building fabric improvements. In an ideal world, you would insulate a property before or alongside installing a heat pump. Better insulation means lower heat demand, which means a smaller heat pump can be specified, which typically runs more efficiently and achieves higher COP. The physics and the economics both point the same way.
+
+Yet the subsidy schemes have never been designed to work together. The RHI actively discouraged insulation by reducing payments when heat demand fell. BUS is agnostic: you receive the same £7,500 whether your home is well-insulated or draughty. Meanwhile, insulation subsidies like ECO (Energy Company Obligation) and the Great British Insulation Scheme operate entirely separately, with different eligibility criteria, different application processes, and no coordination with heat pump grants.
+
+This creates a rushed, technology-first approach. Installers and homeowners focused on capturing the BUS grant install heat pumps into poorly insulated homes, then struggle with high running costs and disappointing COP figures. A fabric-first policy would sequence the work properly: insulation first, then right-size the heat pump to the reduced heat demand. But that would slow down installation numbers, and successive governments have been more interested in headline deployment figures than in ensuring each installation actually works well.
+
+The irony is that fabric-first would ultimately be cheaper for everyone. Smaller heat pumps cost less. Lower heat demand means lower electricity bills. Better COP means less grid reinforcement needed. But without policy coordination, we are instead installing oversized heat pumps into leaky homes, then wondering why performance disappoints and bills remain high.
+
+The shift to BUS, whatever its other merits or drawbacks, at least eliminated the RHI's anti-insulation incentive. A one-off upfront grant has no ongoing relationship with how much heat you produce or consume. Once you've received your £7,500, your incentive is simply to minimise your electricity bills, which means maximising efficiency, exactly as it should be.
+
+However, the grant structure introduces its own problems, and understanding them requires thinking carefully about where estimation risk sits under each scheme.
+
+Under the RHI, payments were typically "deemed" based on the EPC's estimate of heat demand, not the heat pump's actual performance. From May 2018, new heat pump installations were required to have electricity meters fitted to monitor performance, but this didn't change how payments were calculated: you still received deemed payments based on EPC heat demand regardless of what the meter showed. The metering data went to government for research purposes, but poor COP readings had no financial consequence for the homeowner's subsidy.
+
+There was also an optional Metering and Monitoring Service Package (MMSP) that offered additional payments, £805 upfront plus £115 per year, in exchange for sharing detailed performance data. But again, this was about data collection rather than accountability: underperforming systems still received their full deemed payments.
+
+Ironically, it has been community-driven initiatives rather than government schemes that have truly democratised heat pump performance data. Websites like heatpumpmonitor.org, run by the OpenEnergyMonitor project, now host real-time performance data from over 600 heat pump systems across the UK. Homeowners voluntarily share their COP readings, flow temperatures, and electricity consumption, creating a public resource that researchers, installers, and prospective buyers can use to understand what good (and bad) performance actually looks like. This grassroots transparency has done more to highlight the gap between promised and actual performance than the official MMSP data, which largely disappeared into government research reports.
+
+If the installer fitted a system that achieved a COP of 2.2 rather than 3.0, the homeowner still received the same RHI payments, they just paid more in electricity to generate that heat. In theory, the COP risk sat with the homeowner. In practice, the subsidy was so generous that it cushioned even poor performance: at 2025 rates, a system running at COP 2.2 on a 10,000 kWh property would still leave the homeowner roughly breaking even rather than making £500 profit, hardly a disaster.
+
+Under BUS, both risks land squarely on the homeowner with no cushion. The installer receives the grant money upon completion, regardless of how well the heat pump actually performs. If the system delivers COP 2.2 instead of 3.0, the homeowner's electricity cost rises from £800 to £1,090 per year, a £290 annual penalty with no offsetting subsidy. Unlike the RHI recipient who might shrug at reduced profit, the BUS recipient faces genuinely higher bills than they were promised, potentially for the 15-20 year life of the equipment.
+
+The difference between COP 2.2 and 3.0 matters beyond individual bills. Heat pumps draw most electricity on the coldest winter days, precisely when the grid is under greatest pressure. A system running at COP 2.2 instead of 3.0 requires 36% more electricity for the same heat output. Multiply that across millions of heat pumps and the difference becomes a serious grid capacity issue.
+
+To put this in perspective: on the coldest winter days, domestic heat demand from the gas network peaks at around 150-170 GW. If we eventually electrify most of this heating via heat pumps, the electricity demand depends critically on the COP achieved. At COP 3.0, meeting 150 GW of heat demand requires 50 GW of electrical capacity. At COP 2.2, the same heat output requires 68 GW. That 18 GW difference is roughly a third of the UK's current peak electricity demand, equivalent to needing eighteen additional large power stations or offshore wind farms just to compensate for poor installation quality. The infrastructure cost of building and connecting that extra capacity would run into tens of billions of pounds.
+
+Poor installation quality doesn't just cost homeowners money; it increases peak electricity demand, requiring more generation capacity, more grid reinforcement, and ultimately higher system costs passed on to all consumers. Getting COP right is a public good, not just a private concern, yet neither RHI nor BUS created meaningful incentives for installers to optimise performance.
+
+Currently, domestic electricity tariffs charge primarily for energy consumed (kWh), not for peak capacity drawn (kW). This means the extra grid infrastructure costs caused by poorly performing heat pumps are socialised across all consumers rather than borne by those responsible. A household with a well-installed COP 3.5 system subsidises the grid reinforcement needed to supply their neighbour's COP 2.2 installation. This is a classic externality: the installer and homeowner who cut corners on system design face no direct penalty, while the costs are spread invisibly across everyone's bills.
+
+One day, domestic tariffs may move towards capacity-based charging to address this, as is already common for commercial and industrial users. However, such a shift would create significant distributional challenges. Households in older, poorly insulated homes, often those least able to afford retrofits, would face the highest capacity charges. Without careful policy design, capacity pricing risks being regressive, penalising those who inherited draughty housing stock rather than those who made poor installation choices.
+
+There is also a principal-agent problem in the rental sector. Landlords make decisions about insulation, heating systems, and installation quality, but tenants pay the electricity bills. Under capacity-based pricing, a landlord who installs a cheap, poorly-performing heat pump faces no financial consequence; the tenant bears the higher capacity charges. This split incentive already undermines energy efficiency investment in rental properties, and capacity pricing would amplify it further, hitting renters who typically have less financial resilience than owner-occupiers.
+
+This creates a different kind of moral hazard: installers are incentivised to complete installations quickly and move on to the next BUS-funded job, rather than ensuring systems are optimally designed and commissioned for each property. The homeowner may not discover underperformance for months or even years, by which point pursuing complaints becomes difficult. There is no ongoing accountability, no performance guarantee built into the subsidy, and limited recourse beyond standard consumer protections and MCS certification requirements.
+
+## The skills gap
+
+The performance problems cannot be blamed solely on perverse incentives; there is also a genuine shortage of skilled heat pump installers. The government's ambition to install 600,000 heat pumps per year by 2028 requires a workforce that simply does not yet exist. As of 2024, there are around 5,000-6,000 MCS-certified heat pump installers in the UK, many of whom are gas boiler engineers who have retrained.
+
+MCS certification is the gateway to accessing BUS grants, but it is a minimum competency bar rather than a guarantee of quality. The training courses are relatively short, and there is no requirement for ongoing professional development or periodic reassessment. An installer who scraped through certification five years ago and has done mediocre work ever since faces no consequences beyond the occasional customer complaint.
+
+The rapid scaling required to meet deployment targets creates pressure to push installers through training quickly, which inevitably affects quality. Heat pump system design is genuinely complex: it requires understanding the building fabric, calculating heat loss accurately, selecting appropriately sized equipment, designing the heat distribution system (often requiring radiator upgrades), and commissioning the system to run efficiently. This is a broader skill set than fitting a gas boiler, which is essentially a plug-and-play replacement. Yet the training infrastructure has not kept pace with the ambition.
+
+Some in the industry have called for a more rigorous certification regime, including post-installation audits, published performance data by installer, and stronger warranty requirements. But such measures would slow down the installation rate and increase costs, which conflicts with the political imperative to hit headline numbers. The result is a tension between quantity and quality that neither RHI nor BUS has resolved.
+
+## The BUS: upfront capital, flat rate
+
+From 1 April 2022, the Boiler Upgrade Scheme replaced the RHI with an entirely different philosophy. Instead of ongoing payments based on heat produced, BUS offers a one-off upfront grant: initially £5,000 for air source heat pumps, increased to £7,500 from October 2023. Ground source heat pumps also receive £7,500.
+
+This is a fundamentally different incentive structure. Where the RHI rewarded heat production over time and scaled with property size, BUS provides the same flat grant regardless of whether you live in a two-bedroom terrace or a five-bedroom farmhouse. Where the RHI could ultimately deliver over £32,000 for a large property with a ground source system, BUS caps out at £7,500 for everyone.
+
+## Winners and losers: who benefits from each approach?
+
+The shift from RHI to BUS created clear winners and losers.
+
+**Winners under RHI:**
+
+- **Large rural properties off the gas grid.** A detached four or five-bedroom house in the countryside, previously heated by oil, had exactly the profile to maximise RHI payments. High heat demand (often approaching or exceeding the 20,000-30,000 kWh caps) meant maximum tariff income, and the switch from expensive oil to an efficient heat pump generated genuine savings on top of the subsidy income.
+
+- **Ground source heat pump installations.** The much higher GSHP tariff rate (21.16p vs 10.85p) and higher heat demand limit (30,000 kWh vs 20,000 kWh) meant GSHPs could deliver over three times the total subsidy of an equivalent ASHP installation. This made the higher upfront cost of ground source systems (often £15,000-25,000 more than air source) worthwhile for those with suitable land.
+
+- **Those who could afford to wait.** The RHI spread its benefits over seven years, which suited homeowners who didn't need immediate cost reduction and were happy to receive a steady income stream.
+
+**Winners under BUS:**
+
+- **Smaller urban homes on mains gas.** A typical three-bedroom semi in a suburb doesn't have particularly high heat demand, perhaps 10,000-12,000 kWh annually. Under the RHI, this would have generated roughly half the maximum payment. Under BUS, they receive the full £7,500 grant, the same as a property with twice the heat demand.
+
+- **Those who need upfront help.** The biggest barrier to heat pump adoption has always been the capital cost, typically £10,000-15,000 for an air source system. A £7,500 upfront grant cuts this roughly in half immediately, making the decision financially viable for households who couldn't contemplate finding £12,000+ today in exchange for payments spread over seven years.
+
+- **Gas boiler replacements.** Under BUS, urban homes switching from gas boilers are explicitly eligible. These properties were always less attractive under RHI because gas is relatively cheap (unlike oil), so the savings from switching were smaller. The flat BUS grant doesn't discriminate based on your existing fuel source.
+
+**The policy trade-off:**
+
+The government's shift from RHI to BUS reflects a change in priorities. The RHI was designed when heat pump technology was newer and more expensive, and the scheme was intended to reward early adopters and generate returns for those willing to take the plunge. It also cost the government more for larger, higher-demand properties, arguably an inefficient use of subsidy for carbon reduction since a large house getting a heat pump reduces the same amount of carbon per kWh as a small one.
+
+BUS is designed to accelerate mass adoption by tackling the main barrier: upfront cost. It's more egalitarian in the sense that everyone gets the same help, regardless of property size. But it's less generous overall for those with larger properties, particularly those who might have received £20,000-30,000+ under the old regime.
+
+The March 2022 rush demonstrated that plenty of homeowners understood this calculation. Those with larger properties, particularly off-gas-grid homes with high heat demands and existing oil systems, knew the RHI represented their best chance at a generous subsidy. Once BUS arrived, the playing field was levelled, for better or worse, at £7,500 for everyone.
+
+## The hybrid question
+
+There is another approach that neither RHI nor BUS has properly encouraged: hybrid systems combining a heat pump with a gas or oil boiler for backup. The logic is compelling. A heat pump sized to meet perhaps 80% of a home's heat demand, with the existing boiler retained to handle the coldest days, offers several advantages. The heat pump can be smaller and cheaper. It runs most efficiently in milder conditions when it does most of the work. The boiler only fires on the handful of very cold days when heat demand peaks and heat pump efficiency drops. From a grid perspective, this dramatically reduces peak electricity demand, since the gas network handles the winter spikes rather than requiring massive new electrical capacity.
+
+Some European countries, notably Germany, have embraced hybrid installations as a pragmatic transition technology. They accept that the building stock cannot be fully decarbonised overnight and that retaining some gas capacity for peak demand is better than either forcing inadequate heat-pump-only installations or leaving properties on gas entirely.
+
+Yet UK policy has been ambivalent about hybrids. Under the RHI, hybrid installations were possible but complicated: if the fossil fuel boiler contributed significantly, metering requirements kicked in, reducing the simplicity and attractiveness of the scheme. Under BUS, hybrid systems are technically eligible, but the scheme does not specifically encourage them, and the cultural push from government and industry has been towards "pure" heat pump installations.
+
+This all-or-nothing approach may ultimately prove counterproductive. For harder-to-treat properties, particularly solid-walled Victorian terraces and older rural homes, a hybrid system might deliver better real-world performance than an undersized or poorly-performing heat-pump-only installation. It would also reduce the grid infrastructure challenge we discussed earlier. But it requires acknowledging that not every home is ready for full electrification, which sits uncomfortably with policy targets focused on heat pump installation numbers rather than effective carbon reduction.
+
+## Learning from abroad
+
+The UK is not alone in grappling with heat pump policy, and other countries offer instructive comparisons. However, it is worth recognising that the UK is attempting something unusually difficult: retrofitting hydronic (water-based) heat pump systems into a housing stock dominated by gas combi boilers and radiator-based heating. This is a harder challenge than most European comparators face.
+
+**The Nordic countries** are often cited as heat pump success stories, but the comparison flatters to deceive. Norway has heat pumps in over 60% of households, Sweden exceeds 40%. But over 90% of Norwegian installations are air-to-air heat pumps, essentially efficient air conditioners that heat room air directly. This works because Norwegian homes historically used electric radiators rather than gas boilers with hydronic distribution. Installing an air-to-air unit is straightforward: no hot water cylinder needed, no radiator upgrades, no complex heat loss calculations. The heat pump simply replaces or supplements electric heating.
+
+Norway also benefits from heavily subsidised electricity prices, though the story behind this is more politically fraught than it appears. Until 2021, Norwegians enjoyed cheap, stable electricity from their publicly-owned hydropower system. Then two large interconnectors to the UK and Germany came online, exposing Norwegian consumers to European price volatility. Prices spiked, and there was public fury: Norwegians had invested collectively in hydro infrastructure and felt entitled to cheap power, not to subsidise European markets.
+
+The government responded first with "strømstøtte" (electricity support), covering 90% of costs above a threshold of around 75 øre per kWh. From October 2025, this has been supplemented by "Norgespris" (Norway Price), a fixed tariff of 50 øre per kWh (roughly 3.5-4p) for up to 5,000 kWh per month. With grid fees and taxes added, total household costs come to perhaps 10-12p per kWh, still less than half UK levels.
+
+The scheme is politically popular but economically controversial. Critics point out it removes price signals that would encourage energy efficiency, benefits wealthy high-consumption households more than struggling families (a regressive subsidy), and costs the government an estimated NOK 7 billion annually. Most pointedly for heat pump policy, it actually reduces the incentive to invest in efficiency measures: why install a heat pump when electricity is already this cheap? The irony is that Norway's heat pump success predates these subsidies, driven by the switch from electric radiators, and the new pricing regime may actually slow further adoption by weakening the economic case.
+
+The 5,000 kWh monthly cap also creates perverse cliff-edge incentives. A household that comfortably uses 4,000 kWh in a mild month pays the subsidised rate for everything. But in a particularly cold month when they need 6,000 kWh, the picture changes dramatically: the first 5,000 kWh remains at 50 øre, but the final 1,000 kWh is charged at market rates, which in a cold snap could be 150-200 øre or more. The marginal cost of heating during the coldest weather, precisely when heating is most needed, could suddenly be three or four times the subsidised rate. This creates an incentive to under-heat during cold spells to avoid breaching the threshold, or simply to accept a jarring bill shock in the months when it matters most. It is the opposite of the smooth, predictable pricing that the scheme supposedly provides.
+
+Norway has also refused to build any new interconnectors to Europe. In 2023, the government formally rejected NorthConnect, a proposed 1.4 GW cable that would have linked Hardanger to Peterhead in Scotland, despite the project having already received Scottish approval. The Energy Minister declared that Norway does not want to tie itself more strongly to the European power system, and a government minister was blunter: "We need to use Norwegian energy to build Norwegian industry and contribute to competitive prices in Norway." The EU is unhappy, viewing Norway as selfish for hoarding cheap electricity while profiting from gas sales to Europe. But domestically, the message is clear: Norwegian electricity is for Norwegians, at Norwegian prices. This is not a model the UK can replicate.
+
+New Norwegian buildings are different, often featuring underfloor heating, district heating connections, or ground source loops, and face strict regulations including mandatory connection to district heating networks in some municipalities. But the retrofit market, where Norway leads, involves a fundamentally easier technology than what the UK is attempting. Norwegian success does not prove that air-to-water retrofits into radiator systems are equally achievable.
+
+**Germany** provides more generous upfront support, with grants up to €21,000 for heat pump installations under its Federal Funding for Efficient Buildings programme. Crucially, these are income-tested: low-income households receive higher subsidies, recognising that the transition cost falls hardest on those least able to bear it. Germany has also embraced hybrid systems more readily than the UK, viewing them as a pragmatic bridge technology.
+
+**France** takes a fabric-first approach more seriously. Its MaPrimeRénov' scheme offers grants up to €11,000 for geothermal heat pumps, but these are explicitly designed to stack with insulation subsidies and regional bonuses. The system is income-tested and encourages whole-house renovation rather than technology-first installations. The administrative complexity is greater, but the intent is to ensure heat pumps go into properly prepared buildings.
+
+**The Netherlands** offers perhaps the most relevant comparison, facing similar challenges with a gas-dominated housing stock. Dutch policy has arrived at a strikingly different conclusion: from 2026, hybrid heat pumps will be mandatory when replacing a boiler, with a plan to deploy 2 million hybrids by 2030. The Dutch government actively subsidises hybrids, recognising that a heat pump handling 60-80% of heating demand while the gas boiler covers peak loads is a pragmatic transition for homes that are not yet ready for full electrification. The Netherlands has conducted extensive trials and monitoring of hybrid performance in real-world conditions.
+
+The UK, by contrast, explicitly excludes hybrid systems from BUS eligibility. A homeowner who wants to install a heat pump alongside their existing combi boiler, perhaps because they lack space for a hot water cylinder or want to reduce the risk around heat loss sizing and flow temperature capability, receives no government support. This all-or-nothing approach is particularly punishing for the millions of homes with combi boilers, where a hybrid would offer obvious advantages: no need for a cylinder, lower capital cost, smaller heat pump, and a safety net if the heat pump proves undersized or the radiators inadequate. Yet UK policy treats hybrids as an unacceptable compromise rather than a sensible stepping stone.
+
+The UK's electricity-to-gas price ratio of roughly 4:1, among the worst in Europe, makes heat pump economics uniquely challenging. No amount of grant design can fully compensate for a spark gap that renders heat pumps more expensive to run than the gas boilers they replace. Until that fundamental pricing problem is addressed, whether through carbon taxation, electricity levy reform, or other means, uptake will continue to disappoint regardless of how generous the upfront subsidies become.
+
+## What comes next
+
+The BUS has been extended and expanded, with £1.5 billion allocated for 2025-2028, tripling the budget compared to its first three years. The £7,500 grant continues, with capacity to support around 39,000 installations annually. But this is still a long way from the government's target of 600,000 heat pump installations per year by 2028, a number that currently looks more aspirational than achievable.
+
+The more significant policy shift is the Clean Heat Market Mechanism (CHMM), which came into force in April 2025. This places obligations on boiler manufacturers rather than subsidising consumers. Manufacturers must ensure that heat pumps account for a rising percentage of their sales: 6% in the first year, rising to 8-10% in year two. Those who miss their targets face a penalty of £3,000 for each shortfall heat pump, creating a strong financial incentive to push heat pump sales.
+
+The CHMM represents a philosophical shift from carrot to stick. Rather than paying consumers to choose heat pumps, it penalises manufacturers who fail to sell them. In theory, this should drive down heat pump prices as manufacturers compete to meet their quotas and avoid penalties. In practice, it may simply be passed on to boiler customers, raising the cost of gas boiler replacements and making heat pumps relatively more attractive by making the alternative more expensive.
+
+Whether this combination of BUS grants and manufacturer obligations will be enough to reach 600,000 installations per year remains doubtful. The fundamental barriers, high upfront costs, the spark gap, installer shortages, and consumer unfamiliarity, are not fully addressed by either policy. The industry expects continued evolution: further grant increases, possible new financing mechanisms, and ongoing pressure on the electricity-gas price differential. What seems certain is that the policy landscape will continue to shift, and homeowners making heating decisions today cannot assume the current incentive structure will persist.
+
+## Lessons learned
+
+The journey from RHI to BUS illustrates the difficulty of designing subsidy schemes for emerging technologies. Each approach had its logic, and each created unintended consequences.
+
+The RHI succeeded in rewarding early adopters and making heat pumps financially attractive for those with the right properties and the patience to wait for returns. But it created moral hazards around energy efficiency, favoured larger and wealthier households, and became increasingly expensive as energy prices rose. The grandfathering provisions that gave investors confidence also locked the Treasury into commitments it could not adjust.
+
+The BUS addressed the upfront cost barrier that most deters adoption and removed the anti-insulation incentive. But it shifted all performance risk onto homeowners, created no accountability for installer quality, and provides the same flat subsidy regardless of property characteristics or installation difficulty. It does nothing to address the spark gap that makes heat pumps more expensive to run than gas boilers.
+
+Neither scheme has solved the fundamental challenges: the shortage of skilled installers, the lack of coordination with building fabric improvements, the absence of performance guarantees, or the electricity-gas price differential that undermines heat pump economics. Both have prioritised installation numbers over ensuring each installation works well.
+
+Perhaps the most important lesson is that subsidy design matters less than the underlying economics. The Nordic countries achieved high heat pump penetration not through clever grants but through carbon taxes, cheap electricity, and oil bans. Until the UK addresses its unusually high electricity-to-gas price ratio, uptake will remain disappointing regardless of how much is spent on subsidies.
+
+The 30,000+ households who rushed to install heat pumps before the RHI closed in March 2022 will continue receiving inflation-indexed payments until 2029, enjoying economics that make running their heat pumps profitable rather than merely affordable. For everyone else, the calculation is harder, the subsidy less generous, and the outcome more dependent on installation quality and property characteristics. The policy confusion continues.


### PR DESCRIPTION
## Summary

Comprehensive expansion of Chapter 13 analysing the shift from Renewable Heat Incentive (RHI) to Boiler Upgrade Scheme (BUS) for heat pump subsidies.

**Key additions:**
- RHI tariff structure and the March 2022 rush before closure
- Spark gap analysis showing how RHI made heat pumps profitable
- Moral hazard discussion (NI Cash for Ash parallel, insulation disincentive)
- Worked examples for typical semi-detached house
- Fabric-first policy gap and lack of coordination with insulation subsidies
- Skills gap and MCS certification limitations
- BUS estimation risk shifted to homeowners
- Grid capacity impact: 18 GW difference between COP 2.2 and 3.0
- Capacity charging externality and landlord-tenant principal-agent problem
- International comparisons:
  - Norway: Norgespris pricing, air-to-air dominance, NorthConnect rejection
  - Germany: Higher grants, income-tested
  - France: Fabric-first approach
  - Netherlands: Hybrid mandate from 2026
- CHMM manufacturer obligations from 2025
- Conclusion on subsidy design vs underlying economics

**Word count:** ~6,600 words (up from ~1,500)

## Test plan

- [ ] Review chapter flow and narrative coherence
- [ ] Verify factual claims (RHI rates, dates, international policies)
- [ ] Check cross-references to other chapters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Substantial content expansion and restructuring of `chapters/13-rhi-vs-bus.md`, turning it into a comprehensive analysis of UK heat pump subsidy policy.
> 
> - **Explains schemes**: Adds clear definitions of RHI vs BUS and the transition from ongoing tariffs to a flat upfront grant
> - **RHI specifics**: Tariff rates, heat demand caps, CPI indexation, and the March 2022 pre-closure installation spike
> - **Economics**: Spark gap walkthrough showing RHI profitability; worked examples illustrating moral hazard and anti-insulation incentives
> - **Performance risk**: Deemed payments under RHI vs homeowner risk under BUS; COP shortfalls and grid peak demand implications (e.g., 18 GW delta between COP 2.2 vs 3.0)
> - **Externalities**: Capacity-based charging discussion, landlord-tenant principal–agent issues, and installer incentive misalignment
> - **Skills gap**: Limits of MCS certification and workforce scaling challenges
> - **BUS structure**: Flat £7,500 grant, winners/losers by property type, and policy trade-offs
> - **Hybrids**: Case for hybrid systems vs current UK stance and implications for peak demand
> - **International comparisons**: Norway pricing regime and market isolation, Germany/France income-tested and fabric-first grants, Netherlands hybrid mandate
> - **Future policy**: BUS budget extension (2025–2028) and CHMM manufacturer sales obligations; outlook and lessons learned
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9226ffa4f53d93d5af38d6bef52661629277b24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->